### PR TITLE
Refactor OTLP config and improve Wolverine retry policy

### DIFF
--- a/src/Adapters/Inbound/TC.CloudGames.Games.Api/Extensions/ServiceCollectionExtensions.cs
+++ b/src/Adapters/Inbound/TC.CloudGames.Games.Api/Extensions/ServiceCollectionExtensions.cs
@@ -73,8 +73,6 @@
             var serviceVersion = typeof(Program).Assembly.GetName().Version?.ToString() ?? TelemetryConstants.Version;
             var environment = configuration["ASPNETCORE_ENVIRONMENT"] ?? "Development";
             var instanceId = Environment.MachineName;
-            var otlpEndpoint = configuration["OTEL_EXPORTER_OTLP_ENDPOINT"];
-            var otlpHeaders = configuration["OTEL_EXPORTER_OTLP_HEADERS"];
 
             services.AddOpenTelemetry()
                 .ConfigureResource(resource => resource
@@ -110,9 +108,6 @@
                         .AddPrometheusExporter()
                         .AddOtlpExporter(opt =>
                         {
-                            opt.Protocol = OtlpExportProtocol.Grpc;
-                            opt.Endpoint = new Uri(otlpEndpoint ?? "");
-                            opt.Headers = otlpHeaders ?? "";
                             opt.ExportProcessorType = ExportProcessorType.Batch;
                             opt.BatchExportProcessorOptions = new BatchExportProcessorOptions<Activity>
                             {
@@ -205,9 +200,6 @@
                         // OTLP Exporter in batch, async, non-blocking
                         .AddOtlpExporter(opt =>
                         {
-                            opt.Protocol = OtlpExportProtocol.Grpc;
-                            opt.Endpoint = new Uri(otlpEndpoint ?? "");
-                            opt.Headers = otlpHeaders ?? "";
                             opt.ExportProcessorType = ExportProcessorType.Batch;
                             opt.BatchExportProcessorOptions = new BatchExportProcessorOptions<Activity>
                             {
@@ -330,7 +322,8 @@
                         wolverineSchema
                     );
 
-                opts.Policies.OnException<Exception>().RetryTimes(5);
+                ////opts.Policies.OnException<Exception>().RetryTimes(5);
+                opts.Policies.OnAnyException().RetryWithCooldown(TimeSpan.FromMilliseconds(200), TimeSpan.FromMilliseconds(400), TimeSpan.FromMilliseconds(600), TimeSpan.FromMilliseconds(800), TimeSpan.FromMilliseconds(1000));
 
                 // -------------------------------
                 // Enable durable local queues and auto transaction application


### PR DESCRIPTION
This pull request updates the OpenTelemetry and Wolverine messaging configuration in the `TC.CloudGames.Games.Api` adapter. The main changes involve removing explicit OTLP exporter endpoint and header configuration, and updating the exception handling policy for Wolverine messaging to use a cooldown-based retry strategy.

**Telemetry configuration updates:**

* Removed explicit configuration of OTLP exporter protocol, endpoint, and headers in `AddCustomOpenTelemetry`, simplifying the exporter setup. (`src/Adapters/Inbound/TC.CloudGames.Games.Api/Extensions/ServiceCollectionExtensions.cs`) [[1]](diffhunk://#diff-8f1796ae2c05c2dfaf92080142d3c82351fe4a8ec965e7cbb731e57aa7407b1dL76-L77) [[2]](diffhunk://#diff-8f1796ae2c05c2dfaf92080142d3c82351fe4a8ec965e7cbb731e57aa7407b1dL113-L115) [[3]](diffhunk://#diff-8f1796ae2c05c2dfaf92080142d3c82351fe4a8ec965e7cbb731e57aa7407b1dL208-L210)

**Messaging exception handling:**

* Changed Wolverine messaging exception policy from retrying a fixed number of times to retrying with increasing cooldown intervals for any exception, improving resilience and reducing potential overload. (`src/Adapters/Inbound/TC.CloudGames.Games.Api/Extensions/ServiceCollectionExtensions.cs`)Removed OTLP exporter endpoint and headers configuration, including related variables and properties. Updated Wolverine exception handling by replacing fixed retry logic with a cooldown-based retry mechanism. Cleaned up redundant code for better maintainability.