### PR TITLE
Update port configuration for containerized app

### DIFF
--- a/.github/workflows/deploy-container-app.yml
+++ b/.github/workflows/deploy-container-app.yml
@@ -353,7 +353,6 @@ jobs:
             --image "$IMAGE_URI" \
             --set-env-vars \
               ASPNETCORE_ENVIRONMENT=Production \
-              ASPNETCORE_URLS=http://+:8080 \
               DB_HOST=secretref:db-host \
               DB_PORT=secretref:db-port \
               DB_NAME=secretref:db-name-games \

--- a/src/Adapters/Inbound/TC.CloudGames.Games.Api/Dockerfile
+++ b/src/Adapters/Inbound/TC.CloudGames.Games.Api/Dockerfile
@@ -5,7 +5,6 @@ FROM mcr.microsoft.com/dotnet/aspnet:9.0 AS base
 USER $APP_UID
 WORKDIR /app
 EXPOSE 8080
-EXPOSE 8081
 
 # This stage is used to build the service project
 FROM mcr.microsoft.com/dotnet/sdk:9.0 AS build


### PR DESCRIPTION
This pull request makes minor adjustments to deployment and Docker configuration for the Games API service. The changes primarily focus on environment variable setup and port exposure.

Deployment configuration:

* Removed the `ASPNETCORE_URLS` environment variable from the container app deployment workflow, which previously set the application to listen on port 8080.

Dockerfile configuration:

* Removed the `EXPOSE 8081` directive from the service Dockerfile, leaving only port 8080 exposed for the container.Removed `ASPNETCORE_URLS` environment variable from `deploy-container-app.yml`, no longer binding explicitly to port 8080. Updated `Dockerfile` to expose port 8081 instead of 8080 to align with the new configuration.