### PR TITLE
Feature/phase 04

### DIFF
--- a/src/Adapters/Inbound/TC.CloudGames.Games.Api/Extensions/ApplicationBuilderExtensions.cs
+++ b/src/Adapters/Inbound/TC.CloudGames.Games.Api/Extensions/ApplicationBuilderExtensions.cs
@@ -60,7 +60,7 @@ namespace TC.CloudGames.Games.Api.Extensions
         public static IApplicationBuilder UseCustomMiddlewares(this IApplicationBuilder app)
         {
             // Enables proxy headers (important for ACA)
-            app.UseForwardedHeaders(new ForwardedHeadersOptions { ForwardedHeaders = ForwardedHeaders.All });
+            ////app.UseForwardedHeaders(new ForwardedHeadersOptions { ForwardedHeaders = ForwardedHeaders.All });
 
             app.UseCustomExceptionHandler()
                 .UseCorrelationMiddleware()

--- a/src/Adapters/Inbound/TC.CloudGames.Games.Api/Extensions/ServiceCollectionExtensions.cs
+++ b/src/Adapters/Inbound/TC.CloudGames.Games.Api/Extensions/ServiceCollectionExtensions.cs
@@ -412,9 +412,9 @@
                     case BrokerType.AzureServiceBus when broker.ServiceBusSettings is { } sb:
                         var azureOpts = opts.UseAzureServiceBus(sb.ConnectionString,
                             configure =>
-                        {
-                            configure.Identifier = typeof(Program).Assembly.FullName;
-                        });
+                            {
+                                configure.Identifier = typeof(Program).Assembly.GetName().Name;
+                            });
 
                         if (sb.AutoProvision) azureOpts.AutoProvision();
                         if (sb.AutoPurgeOnStartup) azureOpts.AutoPurgeOnStartup();

--- a/src/Adapters/Inbound/TC.CloudGames.Games.Api/Extensions/ServiceCollectionExtensions.cs
+++ b/src/Adapters/Inbound/TC.CloudGames.Games.Api/Extensions/ServiceCollectionExtensions.cs
@@ -410,11 +410,19 @@
                         break;
 
                     case BrokerType.AzureServiceBus when broker.ServiceBusSettings is { } sb:
-                        var azureOpts = opts.UseAzureServiceBus(sb.ConnectionString);
+                        var azureOpts = opts.UseAzureServiceBus(sb.ConnectionString,
+                            configure =>
+                        {
+                            configure.Identifier = typeof(Program).Assembly.FullName;
+                        });
 
                         if (sb.AutoProvision) azureOpts.AutoProvision();
                         if (sb.AutoPurgeOnStartup) azureOpts.AutoPurgeOnStartup();
-                        if (sb.UseControlQueues) azureOpts.EnableWolverineControlQueues();
+                        if (sb.UseControlQueues)
+                        {
+                            azureOpts.EnableWolverineControlQueues();
+                            azureOpts.SystemQueuesAreEnabled(true);
+                        }
 
                         // Durable outbox for all sending endpoints
                         opts.Policies.UseDurableOutboxOnAllSendingEndpoints();


### PR DESCRIPTION
This pull request introduces changes to the Azure Service Bus configuration in the messaging setup and disables the use of forwarded headers in the middleware pipeline. These updates enhance message broker identification and control queue management, while also adjusting proxy header handling.

**Messaging configuration improvements:**

* Set the Azure Service Bus identifier to the assembly name for better traceability and diagnostics in the `AddWolverineMessaging` extension (`ServiceCollectionExtensions.cs`).
* When control queues are enabled, also enable system queues for Azure Service Bus, improving infrastructure management in the same extension.

**Middleware pipeline changes:**

* Disabled the use of forwarded headers by commenting out the related middleware in `UseCustomMiddlewares`, which may affect proxy or load balancer scenarios (`ApplicationBuilderExtensions.cs`).