### PR TITLE
Add adaptive Azure Service Bus configuration

### DIFF
--- a/src/Adapters/Inbound/TC.CloudGames.Games.Api/Extensions/ServiceCollectionExtensions.cs
+++ b/src/Adapters/Inbound/TC.CloudGames.Games.Api/Extensions/ServiceCollectionExtensions.cs
@@ -410,11 +410,7 @@
                         break;
 
                     case BrokerType.AzureServiceBus when broker.ServiceBusSettings is { } sb:
-                        var azureOpts = opts.UseAzureServiceBus(sb.ConnectionString,
-                            configure =>
-                            {
-                                configure.Identifier = typeof(Program).Assembly.GetName().Name;
-                            });
+                        var azureOpts = opts.ConfigureAzureServiceBus(sb, builder.Environment);
 
                         if (sb.AutoProvision) azureOpts.AutoProvision();
                         if (sb.AutoPurgeOnStartup) azureOpts.AutoPurgeOnStartup();

--- a/src/Adapters/Inbound/TC.CloudGames.Games.Api/TC.CloudGames.Games.Api.csproj
+++ b/src/Adapters/Inbound/TC.CloudGames.Games.Api/TC.CloudGames.Games.Api.csproj
@@ -16,7 +16,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.22.1" />
     <PackageReference Include="FastEndpoints.Swagger" Version="7.0.1" />
-    <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="9.0.9" />    
+    <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="9.0.10" />    
     <PackageReference Include="Swashbuckle.AspNetCore" Version="9.0.6" />
     
 		<!-- Logging and Serialization -->
@@ -34,16 +34,16 @@
     <PackageReference Include="AspNetCore.HealthChecks.UI.Client" Version="9.0.0" />
 
 		<!-- Wolverine - ES / MessageBroker / Outbox -->
-		<PackageReference Include="Weasel.Core" Version="8.1.1" />
-		<PackageReference Include="Marten" Version="8.11.0" />
-    <PackageReference Include="WolverineFx" Version="4.12.2" />
-    <PackageReference Include="WolverineFx.AzureServiceBus" Version="4.12.2" />
-    <PackageReference Include="WolverineFx.Marten" Version="4.12.2" />
-    <PackageReference Include="WolverineFx.RabbitMQ" Version="4.12.2" />
+		<PackageReference Include="Weasel.Core" Version="8.2.0" />
+		<PackageReference Include="Marten" Version="8.13.1" />
+    <PackageReference Include="WolverineFx" Version="4.12.3" />
+    <PackageReference Include="WolverineFx.AzureServiceBus" Version="4.12.3" />
+    <PackageReference Include="WolverineFx.Marten" Version="4.12.3" />
+    <PackageReference Include="WolverineFx.RabbitMQ" Version="4.12.3" />
 
 		<!-- OpenTelemetry Core Packages -->
-		<PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.13.0" />
-		<PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.13.0" />
+		<PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.13.1" />
+		<PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.13.1" />
 
 		<!-- OpenTelemetry Instrumentation Packages -->
 		<PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.12.0" />
@@ -52,10 +52,10 @@
 
 		<!-- OpenTelemetry Database and Cache Instrumentation -->
 		<PackageReference Include="OpenTelemetry.Instrumentation.StackExchangeRedis" Version="1.12.0-beta.2" />
-		<PackageReference Include="Npgsql.OpenTelemetry" Version="9.0.3" />
+		<PackageReference Include="Npgsql.OpenTelemetry" Version="9.0.4" />
 
 		<!-- OpenTelemetry Prometheus Exporter -->
-		<PackageReference Include="OpenTelemetry.Exporter.Prometheus.AspNetCore" Version="1.13.0-beta.1" />
+		<PackageReference Include="OpenTelemetry.Exporter.Prometheus.AspNetCore" Version="1.13.1-beta.1" />
 
 		<!-- FusionCache OpenTelemetry Support -->
 		<PackageReference Include="ZiggyCreatures.FusionCache.OpenTelemetry" Version="2.4.0" />

--- a/src/Adapters/Outbound/TC.CloudGames.Games.Infrastructure/TC.CloudGames.Games.Infrastructure.csproj
+++ b/src/Adapters/Outbound/TC.CloudGames.Games.Infrastructure/TC.CloudGames.Games.Infrastructure.csproj
@@ -1,8 +1,8 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <ItemGroup>
-    <PackageReference Include="Marten" Version="8.11.0" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="9.0.9" />
+    <PackageReference Include="Marten" Version="8.13.1" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="9.0.10" />
   </ItemGroup>
   
   <ItemGroup>


### PR DESCRIPTION
This pull request updates several package dependencies across the solution to ensure compatibility with the latest features and bug fixes, and refactors the Azure Service Bus setup logic for improved configuration flexibility. The most significant changes are grouped below:

**Dependency Upgrades:**

* Updated multiple NuGet package versions in `TC.CloudGames.Games.Api.csproj` and `TC.CloudGames.Games.Infrastructure.csproj`, including `Marten`, `WolverineFx` packages, `OpenTelemetry`, and `Microsoft.AspNetCore.OpenApi`, to their latest stable releases for improved stability and new features. [[1]](diffhunk://#diff-5d9d7ff021db8258b6e77cf3d234a578171fbb20bc1dd44f50fe510c54fe221cL19-R19) [[2]](diffhunk://#diff-5d9d7ff021db8258b6e77cf3d234a578171fbb20bc1dd44f50fe510c54fe221cL37-R46) [[3]](diffhunk://#diff-5d9d7ff021db8258b6e77cf3d234a578171fbb20bc1dd44f50fe510c54fe221cL55-R58) [[4]](diffhunk://#diff-f6641517e6839cc6a03a5b39de146876ba313bce5fae87f71a5c2fb149e15894L4-R5)

**Azure Service Bus Configuration Refactor:**

* Refactored the Azure Service Bus configuration in `ServiceCollectionExtensions.cs` to use `ConfigureAzureServiceBus` with environment context, replacing the previous `UseAzureServiceBus` approach for more flexible and environment-aware setup.- Updated `.gitignore` to exclude new secret files.
- Added `Azure.Identity` package for Managed Identity support.
- Refactored `ServiceBusTrigger` to use `AzureWebJobsServiceBus` for adaptive configuration.
- Introduced `EnvironmentServiceConfig` for environment-specific settings.
- Enhanced `ServiceCollectionExtensions` to auto-detect environments and configure Service Bus.
- Added `Namespace` property in appsettings for Managed Identity.
- Created `AZURE_FUNCTIONS_SERVICEBUS_CONFIG.md` to document adaptive configuration.
- Updated dependencies (`Marten`, `WolverineFx`, `OpenTelemetry`) across projects.
- Improved logging and diagnostics for Service Bus setup.
- Centralized Azure Service Bus configuration in `WolverineAzureExtensions`.