### PR TITLE
Refactor OpenAPI/Swagger config to use NSwag best practices

### DIFF
--- a/src/Adapters/Inbound/TC.CloudGames.Games.Api/Extensions/ApplicationBuilderExtensions.cs
+++ b/src/Adapters/Inbound/TC.CloudGames.Games.Api/Extensions/ApplicationBuilderExtensions.cs
@@ -87,19 +87,29 @@ namespace TC.CloudGames.Games.Api.Extensions
 
                     return problemDetails;
                 };
-            })
-            .UseSwaggerGen(uiConfig: ui =>
-            {
-                var pathBase = Environment.GetEnvironmentVariable("ASPNETCORE_APPL_PATH")
-                    ?? configuration["ASPNETCORE_APPL_PATH"]
-                    ?? configuration["PathBase"]
-                    ?? string.Empty;
+            });
 
+            // Get PathBase for server URL modification
+            var pathBase = Environment.GetEnvironmentVariable("ASPNETCORE_APPL_PATH")
+                ?? configuration["ASPNETCORE_APPL_PATH"]
+                ?? configuration["PathBase"]
+                ?? string.Empty;
+
+            // Enable OpenAPI with server modification
+            app.UseOpenApi(o =>
+            {
                 if (!string.IsNullOrWhiteSpace(pathBase))
                 {
-                    ui.ServerUrl = pathBase;
+                    o.PostProcess = (doc, req) =>
+                    {
+                        doc.Servers.Clear();
+                        doc.Servers.Add(new NSwag.OpenApiServer { Url = pathBase });
+                    };
                 }
             });
+
+            // Enable Swagger UI
+            app.UseSwaggerUi(c => c.ConfigureDefaults());
 
             return app;
         }


### PR DESCRIPTION
Replaces .UseSwaggerGen with .UseOpenApi and .UseSwaggerUi, updating server URL handling to use the PostProcess delegate for modifying the OpenAPI document's servers list. This ensures correct PathBase support and separates document generation from UI configuration, following NSwag recommendations.