### PR TITLE
fix(swagger): normalize pathBase to ensure leading slash

### DIFF
--- a/src/Adapters/Inbound/TC.CloudGames.Games.Api/Extensions/ApplicationBuilderExtensions.cs
+++ b/src/Adapters/Inbound/TC.CloudGames.Games.Api/Extensions/ApplicationBuilderExtensions.cs
@@ -153,9 +153,19 @@ namespace TC.CloudGames.Games.Api.Extensions
                 
                 // Use absolute path WITH the PathBase prefix
                 // This ensures the URL is correct regardless of nginx rewriting
-                var swaggerJsonPath = string.IsNullOrEmpty(pathBase) 
-                    ? "/swagger/v1/swagger.json"
-                    : $"{pathBase.TrimEnd('/')}/swagger/v1/swagger.json";
+                // Normalize pathBase to ensure it starts with '/' (handles "games" vs "/games")
+                string swaggerJsonPath;
+                if (string.IsNullOrEmpty(pathBase))
+                {
+                    swaggerJsonPath = "/swagger/v1/swagger.json";
+                }
+                else
+                {
+                    var normalizedPathBase = pathBase.StartsWith('/') 
+                        ? pathBase.TrimEnd('/') 
+                        : $"/{pathBase.TrimEnd('/')}";
+                    swaggerJsonPath = $"{normalizedPathBase}/swagger/v1/swagger.json";
+                }
                 
                 c.SwaggerRoutes.Add(new SwaggerUiRoute("v1", swaggerJsonPath));
                 

--- a/src/Adapters/Inbound/TC.CloudGames.Games.Api/Extensions/ApplicationBuilderExtensions.cs
+++ b/src/Adapters/Inbound/TC.CloudGames.Games.Api/Extensions/ApplicationBuilderExtensions.cs
@@ -115,6 +115,10 @@ namespace TC.CloudGames.Games.Api.Extensions
                 ?? configuration["PathBase"]
                 ?? string.Empty;
 
+            // Normalize pathBase once for reuse in OpenAPI and SwaggerUI
+            // Handles: "games", "/games", "/games/", "/", "  ", null, empty
+            var normalizedPathBase = NormalizePathBase(pathBase);
+
             // Enable OpenAPI/Swagger with proper PathBase handling
             // Key: UseOpenApi MUST be called AFTER UsePathBase middleware (UseIngressPathBase)
             // so that PathBase is already set in the request context
@@ -130,11 +134,11 @@ namespace TC.CloudGames.Games.Api.Extensions
                     // Use the request PathBase (dynamic, from X-Forwarded-Prefix or UsePathBase)
                     if (!string.IsNullOrWhiteSpace(requestPathBase))
                     {
-                        doc.Servers.Add(new NSwag.OpenApiServer { Url = requestPathBase });
+                        doc.Servers.Add(new NSwag.OpenApiServer { Url = NormalizePathBase(requestPathBase) });
                     }
-                    else if (!string.IsNullOrWhiteSpace(pathBase))
+                    else if (!string.IsNullOrEmpty(normalizedPathBase))
                     {
-                        doc.Servers.Add(new NSwag.OpenApiServer { Url = pathBase });
+                        doc.Servers.Add(new NSwag.OpenApiServer { Url = normalizedPathBase });
                     }
                     else
                     {
@@ -151,21 +155,10 @@ namespace TC.CloudGames.Games.Api.Extensions
             {
                 c.SwaggerRoutes.Clear();
                 
-                // Use absolute path WITH the PathBase prefix
-                // This ensures the URL is correct regardless of nginx rewriting
-                // Normalize pathBase to ensure it starts with '/' (handles "games" vs "/games")
-                string swaggerJsonPath;
-                if (string.IsNullOrEmpty(pathBase))
-                {
-                    swaggerJsonPath = "/swagger/v1/swagger.json";
-                }
-                else
-                {
-                    var normalizedPathBase = pathBase.StartsWith('/') 
-                        ? pathBase.TrimEnd('/') 
-                        : $"/{pathBase.TrimEnd('/')}";
-                    swaggerJsonPath = $"{normalizedPathBase}/swagger/v1/swagger.json";
-                }
+                // Build swagger.json path with normalized PathBase
+                var swaggerJsonPath = string.IsNullOrEmpty(normalizedPathBase)
+                    ? "/swagger/v1/swagger.json"
+                    : $"{normalizedPathBase}/swagger/v1/swagger.json";
                 
                 c.SwaggerRoutes.Add(new SwaggerUiRoute("v1", swaggerJsonPath));
                 
@@ -213,6 +206,32 @@ namespace TC.CloudGames.Games.Api.Extensions
             await PostgresDatabaseHelper.EnsureDatabaseExists(connProvider);
 
             return app;
+        }
+
+        /// <summary>
+        /// Normalizes a path base string to ensure it has a leading slash and no trailing slash.
+        /// Handles edge cases: "games", "/games", "/games/", "/", "  ", null, empty string.
+        /// </summary>
+        /// <param name="pathBase">The path base to normalize.</param>
+        /// <returns>Normalized path base (e.g., "/games") or empty string if invalid.</returns>
+        private static string NormalizePathBase(string? pathBase)
+        {
+            if (string.IsNullOrWhiteSpace(pathBase))
+            {
+                return string.Empty;
+            }
+
+            // Trim leading and trailing slashes, then whitespace
+            var trimmed = pathBase.Trim().Trim('/');
+            
+            // If nothing left after trimming (e.g., "/" or "  "), return empty
+            if (string.IsNullOrEmpty(trimmed))
+            {
+                return string.Empty;
+            }
+
+            // Rebuild with single leading slash, no trailing slash
+            return $"/{trimmed}";
         }
     }
 }


### PR DESCRIPTION
Addresses Copilot Code Review suggestion: pathBase string manipulation should ensure it starts with a leading slash to prevent malformed URLs.

If ASPNETCORE_APPL_PATH is set to 'games' instead of '/games', the resulting path would be 'games/swagger/v1/swagger.json' instead of '/games/swagger/v1/swagger.json'.

Now normalizes pathBase before concatenation.